### PR TITLE
ci(#202): Add Auto Release GHA and Enforce Conventional Commit GHA

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,33 @@
+name: Automatic Release
+run-name: Release a new version of the Icons on PR's merging
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  semantic-release:
+    if: "!contains(github.event.head_commit.message, 'ci:')"
+
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      # Checkout data from the repository
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Run Semantic-release-action with the included release
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v4
+        id: semantic # Need an `id` for output variables
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,5 +1,5 @@
 name: Automatic Release
-run-name: Release a new version of the Icons on PR's merging
+run-name: Release a new version of the icon pack on PR's merging
 
 on:
   pull_request:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,23 +4,25 @@ run-name: Release a new version of the icon pack on PR's merging
 on:
   pull_request:
     types:
-      - closed
+      - merged
     branches:
       - main
 
 jobs:
   semantic-release:
-    if: "!contains(github.event.head_commit.message, 'ci:')"
+    if: "!startsWith(github.event.head_commit.message, 'ci')"
 
     name: Semantic Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
+      pull-requests: write
 
     steps:
       # Checkout data from the repository
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -30,4 +32,5 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         id: semantic # Need an `id` for output variables
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use admin FG-PAT
+          GITHUB_TOKEN: ${{ secrets.RELEABOT_TOKEN }}

--- a/.github/workflows/pr-cc.yml
+++ b/.github/workflows/pr-cc.yml
@@ -1,4 +1,4 @@
-name: PR Conventional Commit Validation
+name: Conventional Commit
 run-name: Enforce that PR name follow Conventional Commits
 
 on:
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
-  validate-pr-title:
+  Validate:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation

--- a/.github/workflows/pr-cc.yml
+++ b/.github/workflows/pr-cc.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses:  ytanikin/pr-conventional-commits@1
+        uses:  ytanikin/pr-conventional-commits@1.4.1
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
           add_label: 'false'

--- a/.github/workflows/pr-cc.yml
+++ b/.github/workflows/pr-cc.yml
@@ -1,0 +1,16 @@
+name: PR Conventional Commit Validation
+run-name: Enforce that PR name follow Conventional Commits
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Conventional Commit Validation
+        uses:  ytanikin/PRConventionalCommits@1
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          add_label: 'false'

--- a/.github/workflows/pr-cc.yml
+++ b/.github/workflows/pr-cc.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses:  ytanikin/PRConventionalCommits@1
+        uses:  ytanikin/PRConventionalCommits@v1
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
           add_label: 'false'

--- a/.github/workflows/pr-cc.yml
+++ b/.github/workflows/pr-cc.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses:  ytanikin/PRConventionalCommits@v1
+        uses:  ytanikin/pr-conventional-commits@1
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
           add_label: 'false'

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,9 @@
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/changelog"
+  - "@semantic-release/git"
+  - "@semantic-release/github"
+
+branches: 
+	- main

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,7 +1,7 @@
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
-  - "@semantic-release/changelog"
+#  - "@semantic-release/changelog"
   - "@semantic-release/git"
   - "@semantic-release/github"
 


### PR DESCRIPTION
- Add a Github Action that automatically create a Release and associated Git Tag upon merging a PR that fixes an Icon or feature a new Icon to the Project, using Semantic Releases
- Add a Github Action enforcing any PR to follow the Conventional Commit principles. This will help Semantic Release logs changes in release notes and in a future `CHANGELOG` file
- Closes #202 