### PR TITLE
ci(#215): Fix auto-release not triggered

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,9 +4,9 @@ run-name: Release a new version of the icon pack on PR's merging
 on:
   pull_request:
     types:
-      - merged
+      - closed
     branches:
-      - main
+      - 'main'
 
 jobs:
   semantic-release:

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,7 +1,7 @@
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
-#  - "@semantic-release/changelog"
+  - "@semantic-release/changelog"
   - "@semantic-release/git"
   - "@semantic-release/github"
 


### PR DESCRIPTION
The Workflow file was using an invalid keyword "merged". The right keyword to use is "closed".

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges

```YML
on:
  pull_request:
    types:
      - closed

jobs:
  if_merged:
    if: github.event.pull_request.merged == true
    runs-on: ubuntu-latest
    steps:
    - run: |
        echo The PR was merged
```