### PR TITLE
docs: Use singular they in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # FamFamFam Silk as SVG
 > The iconic iconset of the 2010’s era from Mark James, remade in SVG for today’s needs.
 
-This project contains ~1000 icons in SVG. SVG is lightweight, scalable compared to PNG — and open format, allowing anyone to edit it to his/her needs. I aim to have all the original icons remastered, but also create more up-to-date versions (Smartphones was not a thing back in 2008). Plus, most icons can be mixed with decorators (bullets) to get more meaning. 
+This project contains ~1000 icons in SVG. SVG is lightweight, scalable compared to PNG — and open format, allowing anyone to edit it to their needs. I aim to have all the original icons remastered, but also create more up-to-date versions (Smartphones was not a thing back in 2008). Plus, most icons can be mixed with decorators (bullets) to get more meaning. 
 
 Scale: <img height=16px src="icons/Cup.svg"> <img height=24px src="icons/Cup.svg"> <img height=32px src="icons/Cup.svg"> <img height=48px src="icons/Cup.svg"> <img height=64px src="icons/Cup.svg">
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # FamFamFam Silk as SVG
 > The iconic iconset of the 2010’s era from Mark James, remade in SVG for today’s needs.
 
-This project contains ~1000 icons in SVG. SVG is lightweight, scalable compared to PNG — and open format, allowing anyone to edit it to their needs. I aim to have all the original icons remastered, but also create more up-to-date versions (Smartphones was not a thing back in 2008). Plus, most icons can be mixed with decorators (bullets) to get more meaning. 
+This project contains ~1000 icons in SVG. SVG is lightweight and scalable compared to PNG — an open format, allowing anyone to edit it to their needs. I aim to have all the original icons remastered, but also create more up-to-date versions (smartphones were not a thing back in 2008). Plus, most icons can be mixed with decorators (bullets) to add more meaning. 
 
 Scale: <img width="16" src="icons/Cup.svg"> <img width="20" src="icons/Cup.svg"> <img width="32" src="icons/Cup.svg"> <img width="48" src="icons/Cup.svg"> <img width="64" src="icons/Cup.svg">
 
@@ -70,9 +70,9 @@ This project is licensed under the [**Creative Commons BY 4**](https://creativec
 
 The Original *FamFamFam Silk* icon pack ([github](https://github.com/markjames/famfamfam-silk-icons) • [website](http://www.famfamfam.com/lab/icons/silk/)) remains the property of Mark James. Mark, please have my thanks and salute for your great work.
 
-#### About IA
+#### About AI
 
-**No IA has been involved so far**, and hopefully as little and late as possible in the future. AI may be used indirectly (chores, triaging, ideating, …), not as the main activity of this project (i.e.: generating icons, training on Mark's style, …).
+**No AI has been utilized so far**, and hopefully will be used as little as possible in the future. AI may be used indirectly (chores, triaging, ideating, …), but not for the main activities of this project (i.e.: generating icons, training on Mark's style, …).
 
 #### Fonts
 - [Fira Mono](https://github.com/mozilla/Fira)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Thank you! Please *Fork* → *Patch* → *Push* → *Pull Request* and follow th
 - Icons must be designed to be **legible in any size from 16×16px to 64×64px**. It must have the right balance between too much details and too little. I recommand using a grid of 16×16 to help.
 - Icon improvement based on existing icons must be as close as possible to the original design, especially at 16×16px.
 - Icon must render without visual artefact in today's broswer such as WebKit, Blink, Gecko. (Test your icons)
-- Please do not use AI and help conserve the planet's resources ![globe icon](https://raw.githubusercontent.com/roxwize/famfamfam-silk-svg/refs/heads/main/icons/World.svg)
+- Please avoid using AI and help conserve the planet's resources ![globe icon](https://raw.githubusercontent.com/roxwize/famfamfam-silk-svg/refs/heads/main/icons/World.svg)
 
 ## License <img height=30px src="icons/Report.svg">
 
@@ -71,7 +71,7 @@ The Original *FamFamFam Silk* icon pack ([github](https://github.com/markjames/f
 
 #### About IA
 
-No IA has been involved in the making so far, and if possible not in the near future. I may use AI indirectly for chores, triaging, ideating, but not for generating icons themself.
+No IA has been involved so far, and as little as possible in the near future. AI may be used indirectly for chores, triaging, ideating, but not for generating icons themself.
 
 #### Fonts
 - [Fira Mono](https://github.com/mozilla/Fira)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 This project contains ~1000 icons in SVG. SVG is lightweight, scalable compared to PNG — and open format, allowing anyone to edit it to their needs. I aim to have all the original icons remastered, but also create more up-to-date versions (Smartphones was not a thing back in 2008). Plus, most icons can be mixed with decorators (bullets) to get more meaning. 
 
+Scale: <img width="16" src="icons/Cup.svg"> <img width="24" src="icons/Cup.svg"> <img width="32" src="icons/Cup.svg"> <img width="48" src="icons/Cup.svg"> <img width="64" src="icons/Cup.svg">
+
 Mix: ![Cup of caffee](<public/Cup of caffe.svg>) + ![Bullet delete](<icons/Bullet delete.svg>) = ![A cup of caffe with a delete bullet at its bottom right](<public/I should stop caffe.svg>)
 
 Customize: ![Cup of caffee](<public/Cup of caffe.svg>) ![Cup of Matcha latte](<public/Cup of matcha.svg>) ![Cup of Tea](<public/Cup of tea.svg>) ![Cup of water](<public/Cup of water.svg>)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 This project contains ~1000 icons in SVG. SVG is lightweight, scalable compared to PNG — and open format, allowing anyone to edit it to their needs. I aim to have all the original icons remastered, but also create more up-to-date versions (Smartphones was not a thing back in 2008). Plus, most icons can be mixed with decorators (bullets) to get more meaning. 
 
-Scale: <img height=16px src="icons/Cup.svg"> <img height=24px src="icons/Cup.svg"> <img height=32px src="icons/Cup.svg"> <img height=48px src="icons/Cup.svg"> <img height=64px src="icons/Cup.svg">
-
 Mix: ![Cup of caffee](<public/Cup of caffe.svg>) + ![Bullet delete](<icons/Bullet delete.svg>) = ![A cup of caffe with a delete bullet at its bottom right](<public/I should stop caffe.svg>)
 
 Customize: ![Cup of caffee](<public/Cup of caffe.svg>) ![Cup of Matcha latte](<public/Cup of matcha.svg>) ![Cup of Tea](<public/Cup of tea.svg>) ![Cup of water](<public/Cup of water.svg>)
@@ -60,14 +58,20 @@ Thank you! Please *Fork* → *Patch* → *Push* → *Pull Request* and follow th
 - Icons must be designed to be **legible in any size from 16×16px to 64×64px**. It must have the right balance between too much details and too little. I recommand using a grid of 16×16 to help.
 - Icon improvement based on existing icons must be as close as possible to the original design, especially at 16×16px.
 - Icon must render without visual artefact in today's broswer such as WebKit, Blink, Gecko. (Test your icons)
+- Please do not use AI and help conserve the planet's resources ![globe icon](https://raw.githubusercontent.com/roxwize/famfamfam-silk-svg/refs/heads/main/icons/World.svg)
 
 ## License <img height=30px src="icons/Report.svg">
 
 This project is licensed under the [**Creative Commons BY 4**](https://creativecommons.org/licenses/by/4.0/) license. This content is distributed in the hope that it will be useful, but **without any warranty**; without even the implied warranty of **merchantability** or **fitness for a particular purpose**.
 
+
 ## Acknowlegements <img height=30px src="icons/Heart.svg">
 
 The Original *FamFamFam Silk* icon pack ([github](https://github.com/markjames/famfamfam-silk-icons) • [website](http://www.famfamfam.com/lab/icons/silk/)) remains the property of Mark James. Mark, please have my thanks and salute for your great work.
+
+#### About IA
+
+No IA has been involved in the making so far, and if possible not in the near future. I may use AI indirectly for chores, triaging, ideating, but not for generating icons themself.
 
 #### Fonts
 - [Fira Mono](https://github.com/mozilla/Fira)

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 This project contains ~1000 icons in SVG. SVG is lightweight, scalable compared to PNG — and open format, allowing anyone to edit it to their needs. I aim to have all the original icons remastered, but also create more up-to-date versions (Smartphones was not a thing back in 2008). Plus, most icons can be mixed with decorators (bullets) to get more meaning. 
 
-Scale: <img width="16" src="icons/Cup.svg"> <img width="24" src="icons/Cup.svg"> <img width="32" src="icons/Cup.svg"> <img width="48" src="icons/Cup.svg"> <img width="64" src="icons/Cup.svg">
+Scale: <img width="16" src="icons/Cup.svg"> <img width="20" src="icons/Cup.svg"> <img width="32" src="icons/Cup.svg"> <img width="48" src="icons/Cup.svg"> <img width="64" src="icons/Cup.svg">
 
 Mix: ![Cup of caffee](<public/Cup of caffe.svg>) + ![Bullet delete](<icons/Bullet delete.svg>) = ![A cup of caffe with a delete bullet at its bottom right](<public/I should stop caffe.svg>)
 
 Customize: ![Cup of caffee](<public/Cup of caffe.svg>) ![Cup of Matcha latte](<public/Cup of matcha.svg>) ![Cup of Tea](<public/Cup of tea.svg>) ![Cup of water](<public/Cup of water.svg>)
 
-## How to use <img height=30px src="icons/Help.svg">
+## How to use <img width="20" src="icons/Help.svg">
 
 * Clone or fork the repository.
 * Download files from the [icons](./icons/) folder.
@@ -21,18 +21,18 @@ Currently available icons:
 
 ![All decorators](./public/available-decorators.png)
 
-### <img height=24px src="icons/Date.svg"> Roadmap
+### <img width="16" src="icons/Date.svg"> Roadmap
 
 * <img src="icons/Tick.svg"> ~~Access to decorators~~ 
 * <img src="icons/Hourglass.svg"> Access to variants
 * <img src="icons/Hourglass.svg"> Access to parts
 * <img src="icons/Hourglass.svg"> Designers: Get the Figma UI Kit
 
-## Contributing <img height=30px src="icons/Paintbrush.svg">
+## Contributing <img width="20" src="icons/Paintbrush.svg">
 
 Reports, Requests and Contributions are welcomed to this project! I believe that healthy debate and disagreement are essential to a healthy project and community. However, it is never ok to be disrespectful.
 
-### <img height=24px src="icons/Bug.svg">  I would like to report a bug or suggest something!
+### <img width="16" src="icons/Bug.svg">  I would like to report a bug or suggest something!
 
 The issue section is the right place for you to describe your problem. Specific rules applies, and not following them may result in the closing of the issue.
 * Issue must have a label related to your topic
@@ -40,21 +40,21 @@ The issue section is the right place for you to describe your problem. Specific 
 * Issue may be flagged as _duplicate_ if the topic is already discussed on another issue.
 * There is no garanties that an Issue will be resolved. I have limited bandwidth.
 
-### <img height=24px src="icons/Wand.svg">  Can I create an icon too?
+### <img width="16" src="icons/Wand.svg">  Can I create an icon too?
 
 Sure! Please *Fork* → *Create* → *Push* → *Pull Request*, follow the [Pull Request & commits guidelines](#pull-request-and-commit-guidelines), and the [Icon Design guidelines](#icon-design-guidelines) below.
 
-### <img height=24px src="icons/Wrench.svg">  I have fixed this icon, how can I give it back?
+### <img width="16" src="icons/Wrench.svg">  I have fixed this icon, how can I give it back?
 
 Thank you! Please *Fork* → *Patch* → *Push* → *Pull Request* and follow the [Pull Request & commits guidelines](#pull-request-and-commit-guidelines), and the [Icon Design guidelines](#icon-design-guidelines) below.
 
-### Pull Request and Commit Guidelines
+### <img width="16" src="icons/Arrow Join.svg">  Pull Request and Commit Guidelines
 - It should stick to the [community's best practices](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews) as close as possible
 - It must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) principles in commit and PR names.
 - It must be related to an issue in this project.
 - Authors of contribution are credited (via the Contributor section of Github)
 
-### Icon Design Guidelines
+### <img width="16" src="icons/Report picture.svg">  Icon Design Guidelines
 - Icons must be in the **style and spirit of the original work** from Mark James.
 - Icons must be in **SVG**.
 - Icons must be designed to be **legible in any size from 16×16px to 64×64px**. It must have the right balance between too much details and too little. I recommand using a grid of 16×16 to help.
@@ -62,11 +62,11 @@ Thank you! Please *Fork* → *Patch* → *Push* → *Pull Request* and follow th
 - Icon must render without visual artefact in today's broswer such as WebKit, Blink, Gecko. (Test your icons)
 - Please avoid using AI and help conserve the planet's resources ![globe icon](https://raw.githubusercontent.com/roxwize/famfamfam-silk-svg/refs/heads/main/icons/World.svg)
 
-## License <img height=30px src="icons/Report.svg">
+## License <img width="20" src="icons/Report.svg">
 
 This project is licensed under the [**Creative Commons BY 4**](https://creativecommons.org/licenses/by/4.0/) license. This content is distributed in the hope that it will be useful, but **without any warranty**; without even the implied warranty of **merchantability** or **fitness for a particular purpose**.
 
-## Acknowlegements <img height=30px src="icons/Heart.svg">
+## Acknowlegements <img width="20" src="icons/Heart.svg">
 
 The Original *FamFamFam Silk* icon pack ([github](https://github.com/markjames/famfamfam-silk-icons) • [website](http://www.famfamfam.com/lab/icons/silk/)) remains the property of Mark James. Mark, please have my thanks and salute for your great work.
 

--- a/README.md
+++ b/README.md
@@ -66,14 +66,13 @@ Thank you! Please *Fork* → *Patch* → *Push* → *Pull Request* and follow th
 
 This project is licensed under the [**Creative Commons BY 4**](https://creativecommons.org/licenses/by/4.0/) license. This content is distributed in the hope that it will be useful, but **without any warranty**; without even the implied warranty of **merchantability** or **fitness for a particular purpose**.
 
-
 ## Acknowlegements <img height=30px src="icons/Heart.svg">
 
 The Original *FamFamFam Silk* icon pack ([github](https://github.com/markjames/famfamfam-silk-icons) • [website](http://www.famfamfam.com/lab/icons/silk/)) remains the property of Mark James. Mark, please have my thanks and salute for your great work.
 
 #### About IA
 
-No IA has been involved so far, and as little as possible in the near future. AI may be used indirectly for chores, triaging, ideating, but not for generating icons themself.
+**No IA has been involved so far**, and hopefully as little and late as possible in the future. AI may be used indirectly (chores, triaging, ideating, …), not as the main activity of this project (i.e.: generating icons, training on Mark's style, …).
 
 #### Fonts
 - [Fira Mono](https://github.com/mozilla/Fira)


### PR DESCRIPTION
This patch just changes the lead of the README to use more appropriate language.

```patch
- scalable compared to PNG — and open format, allowing anyone to edit it to his/her needs.
+ scalable compared to PNG — and open format, allowing anyone to edit it to their needs.
```

I don't like to throw the word "inclusive" around, but... "his/her" is an rather clunky bodge of a practice in English and the use of [singular they](https://en.wikipedia.org/wiki/Singular_they) is common practice today—there's no reason not to do it, lest we exclude those who are neither he's nor she's from the stated goal of this project.

One/oneself is also a reasonable alternative, preference permitting.

```patch
- scalable compared to PNG — and open format, allowing anyone to edit it to his/her needs.
+ scalable compared to PNG — and open format, allowing anyone to edit it to one's needs.
```

I'll leave it up to you to pick one that you think fits best.